### PR TITLE
Adjust printing to useful standards for production calcs

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Test and generate coverage report
       run: |
         pip install coverage
-        coverage run -m pytest
+        coverage run -m pytest -s magpy/tests/test_021_VCD_MP2.py
         coverage xml 
         ls -l
 

--- a/magpy/aat.py
+++ b/magpy/aat.py
@@ -324,8 +324,10 @@ class AAT(object):
                     AAT_DD[R,B] = AAT_DD_element(R_disp, B_disp, R_pos[R].C2, R_neg[R].C2, B_pos[B].C2, B_neg[B].C2, S[R][B], orbitals)
 
         if print_level >= 1:
-            print("Correlated AAT (normalized):")
+            print("Correlated AAT (normalization = {self.normalization}):")
             print(AAT_DD)
+            print("Total electronic AAT (normalization = {self.normalization}):")
+            print(AAT_00 + AAT_DD)
 
         return AAT_00, AAT_0D, AAT_D0, AAT_DD
 

--- a/magpy/aat.py
+++ b/magpy/aat.py
@@ -47,7 +47,7 @@ class AAT(object):
         self.parallel = kwargs.pop('parallel', False)
         if self.parallel is True:
             self.num_procs = kwargs.pop('num_procs', 4)
-            print(f"AATs will be computed using parallel algorithm with {num_procs:d} processes.")
+            print(f"AATs will be computed using parallel algorithm with {self.num_procs:d} processes.")
 
         # Extract kwargs
         e_conv = kwargs.pop('e_conv', 1e-10)
@@ -56,6 +56,24 @@ class AAT(object):
         max_diis = kwargs.pop('max_diis', 8)
         start_diis = kwargs.pop('start_diis', 1)
         print_level = kwargs.pop('print_level', 0)
+
+        # Title output
+        if print_level >= 1:
+            print("\nAtomic Axial Tensor Computation")
+            print("=================================")
+            print(f"    Method = {method:s}")
+            print(f"    Orbitals = {orbitals:s}")
+            print(f"    Normalization = {normalization:s}")
+            print(f"    parallel = {self.parallel}")
+            if self.parallel is True:
+                print(f"    num_procs = {self.num_procs:d}")
+            print(f"    r_disp = {R_disp:e}")
+            print(f"    b_disp = {B_disp:e}")
+            print(f"    e_conv = {e_conv:e}")
+            print(f"    r_conv = {r_conv:e}")
+            print(f"    maxiter = {maxiter:d}")
+            print(f"    max_diis = {max_diis:d}")
+            print(f"    start_diis = {start_diis:d}")
 
         mol = self.molecule
 
@@ -260,6 +278,10 @@ class AAT(object):
                     mm = det_overlap(self.orbitals, [0], [0], S[R][B][3], o, spins='AAAA') * C0_R_neg * C0_B_neg
                     AAT_00[R,B] = (((pp - pm - mp + mm)/(4*R_disp*B_disp))).imag
 
+        if print_level >= 1:
+            print(f"Hartree-Fock AAT (normalization = {self.normalization:s}):")
+            print(AAT_00)
+
         if method == 'HF':
             return AAT_00
 
@@ -300,6 +322,10 @@ class AAT(object):
 
                     # <dD/dR|dD/dB>
                     AAT_DD[R,B] = AAT_DD_element(R_disp, B_disp, R_pos[R].C2, R_neg[R].C2, B_pos[B].C2, B_neg[B].C2, S[R][B], orbitals)
+
+        if print_level >= 1:
+            print("Correlated AAT (normalized):")
+            print(AAT_DD)
 
         return AAT_00, AAT_0D, AAT_D0, AAT_DD
 

--- a/magpy/aat.py
+++ b/magpy/aat.py
@@ -63,7 +63,7 @@ class AAT(object):
         H = magpy.Hamiltonian(mol)
         scf0 = magpy.hfwfn(H, self.charge, self.spin)
         scf0.solve(e_conv=e_conv, r_conv=r_conv, maxiter=maxiter, max_diis=max_diis, start_diis=start_diis, print_level=print_level)
-        if print_level > 0:
+        if print_level > 2:
             print("Psi4 SCF = ", self.run_psi4_scf(H.molecule))
         if method == 'CID':
             if orbitals == 'SPATIAL':
@@ -83,7 +83,7 @@ class AAT(object):
             strength = np.zeros(3)
 
             # +B displacement
-            if print_level > 0:
+            if print_level > 2:
                 print("B(%d)+ Displacement" % (B))
             strength[B] = B_disp
             H = magpy.Hamiltonian(mol)
@@ -109,7 +109,7 @@ class AAT(object):
                 B_pos.append(ci)
 
             # -B displacement
-            if print_level > 0:
+            if print_level > 2:
                 print("B(%d)- Displacement" % (B))
             strength[B] = -B_disp
             H = magpy.Hamiltonian(mol)
@@ -140,13 +140,13 @@ class AAT(object):
         for R in range(3*mol.natom()):
 
             # +R displacement
-            if print_level > 0:
+            if print_level > 2:
                 print("R(%d)+ Displacement" % (R))
             H = magpy.Hamiltonian(shift_geom(mol, R, R_disp))
             rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
             scf = magpy.hfwfn(H, self.charge, self.spin)
             scf.solve(e_conv=e_conv, r_conv=r_conv, maxiter=maxiter, max_diis=max_diis, start_diis=start_diis, print_level=print_level)
-            if print_level > 0:
+            if print_level > 2:
                 print("Psi4 SCF = ", self.run_psi4_scf(H.molecule))
             scf.match_phase(scf0)
             if method == 'HF':
@@ -167,12 +167,12 @@ class AAT(object):
                 R_pos.append(ci)
 
             # -R displacement
-            if print_level > 0:
+            if print_level > 2:
                 print("R(%d)- Displacement" % (R))
             H = magpy.Hamiltonian(shift_geom(mol, R, -R_disp))
             scf = magpy.hfwfn(H, self.charge, self.spin)
             scf.solve(e_conv=e_conv, r_conv=r_conv, maxiter=maxiter, max_diis=max_diis, start_diis=start_diis, print_level=print_level)
-            if print_level > 0:
+            if print_level > 2:
                 print("Psi4 SCF = ", self.run_psi4_scf(H.molecule))
             scf.match_phase(scf0)
             if method == 'HF':

--- a/magpy/apt.py
+++ b/magpy/apt.py
@@ -39,6 +39,19 @@ class APT(object):
         start_diis = kwargs.pop('start_diis', 1)
         print_level = kwargs.pop('print_level', 0)
 
+        # Title output
+        if print_level >= 1:
+            print("\nAtomic Polar Tensor Computation")
+            print("=================================")
+            print(f"    Method = {method:s}")
+            print(f"    r_disp = {R_disp:e}")
+            print(f"    f_disp = {F_disp:e}")
+            print(f"    e_conv = {e_conv:e}")
+            print(f"    r_conv = {r_conv:e}")
+            print(f"    maxiter = {maxiter:d}")
+            print(f"    max_diis = {max_diis:d}")
+            print(f"    start_diis = {start_diis:d}")
+
         params = [e_conv, r_conv, maxiter, max_diis, start_diis, print_level]
 
         if print_level > 1:

--- a/magpy/apt.py
+++ b/magpy/apt.py
@@ -41,7 +41,7 @@ class APT(object):
 
         params = [e_conv, r_conv, maxiter, max_diis, start_diis, print_level]
 
-        if print_level > 0:
+        if print_level > 1:
             print("Initial geometry:")
             print(self.molecule.geometry().np)
 
@@ -54,9 +54,9 @@ class APT(object):
 
             dipder[R] = (mu_p - mu_m)/(2*R_disp)
 
-#        if print_level > 0:
-        print("APT (Eh/(e a0^2))")
-        print(dipder)
+        if print_level > 0:
+            print("APT (Eh/(e a0^2))")
+            print(dipder)
 
         return dipder
 
@@ -109,7 +109,7 @@ class APT(object):
 
             mu[beta] = -(E_pos - E_neg)/(2 * F_disp)
 
-        if print_level > 0:
+        if print_level > 2:
             print("Dipole moment = ", mu)
 
         return mu

--- a/magpy/ciwfn.py
+++ b/magpy/ciwfn.py
@@ -86,7 +86,7 @@ class ciwfn(object):
         start_diis = kwargs.pop('start_diis', 1)
         print_level = kwargs.pop('print_level', 0)
 
-        if print_level > 0:
+        if print_level > 2:
             print("\nNMO = %d; NACT = %d; NO = %d; NV = %d" % (self.hfwfn.nbf, self.nt, self.no, self.nv))
 
         o = self.o
@@ -101,13 +101,13 @@ class ciwfn(object):
         # SCF check
         ESCF = self.efzc + 2.0 * contract('ii->',self.h[o,o]) + contract('ijij->', L[o,o,o,o])
         E0 = self.hfwfn.escf + self.hfwfn.H.enuc
-        if print_level > 0:
+        if print_level > 2:
             print("\nESCF (electronic) = ", ESCF)
             print("ESCF (total) =      ", ESCF+self.hfwfn.H.enuc)
             print("HFWFN ESCF (electronic) = ", self.hfwfn.escf)
             print("HFWFN ESCF (total) =      ", self.hfwfn.escf + self.hfwfn.enuc)
 
-        if print_level > 0:
+        if print_level > 2:
             print("\nSolving projected CID equations.")
 
         # initial guess amplitudes
@@ -120,7 +120,7 @@ class ciwfn(object):
         # Setup DIIS object
         diis = DIIS(C2, max_diis)
 
-        if print_level > 0:
+        if print_level > 2:
             print("CID Iter %3d: CID Ecorr = %.15f  dE = %.5E  MP2" % (0, eci, -eci))
 
         ediff = eci
@@ -139,11 +139,11 @@ class ciwfn(object):
 
             ediff = eci - eci_last
 
-            if print_level > 0:
+            if print_level > 2:
                 print('CID Iter %3d: CID Ecorr = %.15f  dE = %.5E  rms = %.5E' % (niter, eci, ediff, rms))
 
             if ((abs(ediff) < e_conv) and (abs(rms) < r_conv)):
-                if print_level > 0:
+                if print_level > 2:
                     print("\nCID Equations converged.")
                     print("CID Correlation Energy = ", eci)
                     print("CID Total Energy       = ", eci + E0)
@@ -152,7 +152,7 @@ class ciwfn(object):
                 if self.normalization == 'FULL':
                     C0, C2 = self.normalize(o, v, C2)
                     norm = np.sqrt(C0*C0 + 2.0 * contract('ijab,ijab->', C2.conj(), C2) - contract('ijab,ijba', C2.conj(), C2))
-                    if print_level > 0:
+                    if print_level > 2:
                         print(f"Normalization check = {norm:18.12f}")
 
                 self.C0 = C0

--- a/magpy/ciwfn_so.py
+++ b/magpy/ciwfn_so.py
@@ -101,7 +101,7 @@ class ciwfn_so(object):
         start_diis = kwargs.pop('start_diis', 1)
         print_level = kwargs.pop('print_level', 0)
 
-        if print_level > 0:
+        if print_level > 2:
             print("\nNMO = %d; NACT = %d; NO = %d; NV = %d" % (self.hfwfn.nbf, self.nt, self.no, self.nv))
 
         o = self.o
@@ -115,13 +115,13 @@ class ciwfn_so(object):
         # SCF check
         ESCF = contract('ii->',self.h[o,o]) + 0.5 * contract('ijij->', ERI[o,o,o,o])
         E0 = self.hfwfn.escf + self.hfwfn.H.enuc
-        if print_level > 0:
+        if print_level > 2:
             print("ESCF (electronic) = ", ESCF)
             print("ESCF (total) =      ", ESCF+self.hfwfn.H.enuc)
             print("HFWFN ESCF (electronic) = ", self.hfwfn.escf)
             print("HFWFN ESCF (total) =      ", self.hfwfn.escf + self.hfwfn.enuc)
 
-        if print_level > 0:
+        if print_level > 2:
             print("\nSolving projected CID equations.")
 
         # initial guess amplitudes -- intermediate normalization
@@ -134,7 +134,7 @@ class ciwfn_so(object):
         # Setup DIIS object
         diis = DIIS(C2, max_diis)
 
-        if print_level > 0:
+        if print_level > 2:
             print("CID Iter %3d: CID Ecorr = %.15f  dE = %.5E  MP2" % (0, eci, -eci))
 
         ediff = eci
@@ -152,11 +152,11 @@ class ciwfn_so(object):
 
             ediff = eci - eci_last
 
-            if print_level > 0:
+            if print_level > 2:
                 print('CID Iter %3d: CID Ecorr = %.15f  dE = %.5E  rms = %.5E' % (niter, eci, ediff, rms))
 
             if ((abs(ediff) < e_conv) and (abs(rms) < r_conv)):
-                if print_level > 0:
+                if print_level > 2:
                     print("\nCID Equations converged.")
                     print("CID Correlation Energy = ", eci)
                     print("CID Total Energy       = ", eci + E0)
@@ -165,7 +165,7 @@ class ciwfn_so(object):
                 if self.normalization == 'FULL':
                     C0, C2 = self.normalize(o, v, C2)
                     norm = np.sqrt(C0*C0 + (1/4) * contract('ijab,ijab', C2.conj(), C2))
-                    if print_level > 0:
+                    if print_level > 2:
                         print(f"Normalization check = {norm:18.12f}")
                 self.C0 = C0
                 self.C2 = C2

--- a/magpy/hessian.py
+++ b/magpy/hessian.py
@@ -41,7 +41,7 @@ class Hessian(object):
 
         params = [e_conv, r_conv, maxiter, max_diis, start_diis, print_level]
 
-        if print_level > 0:
+        if print_level > 1:
             print("Initial geometry:")
             print(self.molecule.geometry().np)
 
@@ -68,9 +68,10 @@ class Hessian(object):
 
                     hess[R,R] = -(E2p - 16*Ep + 30*E0 - 16*Em + E2m)/(12*disp*disp)
 
-#        if print_level > 0:
-        print("Hessian (Eh/a0^2)")
-        print(hess)
+        if print_level > 1:
+            print("Hessian (Eh/a0^2)")
+            print(hess)
+
         return hess
 
 
@@ -88,7 +89,7 @@ class Hessian(object):
         H = magpy.Hamiltonian(shift_geom(shift_geom(self.molecule, M1*3+alpha1, disp1), M2*3+alpha2, disp2))
         scf = magpy.hfwfn(H, self.charge, self.spin)
         escf, C = scf.solve(e_conv=e_conv, r_conv=r_conv, maxiter=maxiter, max_diis=max_diis, start_diis=start_diis, print_level=print_level)
-        if print_level > 0:
+        if print_level > 2:
             print(f"{M1:d}, {alpha1:d}; {M2:d}, {alpha2:d} ::: {disp1:0.5f}; {disp2:0.5f}")
             print(H.molecule.geometry().np)
             print(f"ESCF = {escf:18.15f}")

--- a/magpy/hfwfn.py
+++ b/magpy/hfwfn.py
@@ -68,7 +68,7 @@ class hfwfn(object):
         # Setup DIIS object
         diis = DIIS(F, max_diis)
 
-        if print_level > 0:
+        if print_level > 2:
             print("\n  Nuclear repulsion energy = %20.12f" % self.enuc)
             print("\n Iter     E(elec,real)          E(elec,imag)             E(tot)                Delta(E)              RMS(D)")
             print(" %02d %20.13f %20.13f %20.13f" % (0, escf.real, escf.imag, escf.real + self.enuc))
@@ -99,7 +99,7 @@ class hfwfn(object):
             ediff = (escf - escf_last).real
             rms = np.linalg.norm(D-D_last).real
 
-            if print_level > 0:
+            if print_level > 2:
                 print(" %02d %20.13f %20.13f %20.13f %20.13f %20.13f" % (niter, escf.real, escf.imag, escf.real + self.enuc, ediff, rms))
 
             # Check for convergence
@@ -107,7 +107,7 @@ class hfwfn(object):
                 self.escf = escf
                 self.C = C
                 self.eps = eps
-                if print_level > 0:
+                if print_level > 2:
                     print("E(SCF) =  %20.15f" % (escf + self.enuc))
                 return (escf+self.enuc), C
 

--- a/magpy/mpwfn.py
+++ b/magpy/mpwfn.py
@@ -84,7 +84,7 @@ class mpwfn(object):
             raise Exception(f"{normalization:s} is not an allowed choice of normalization.")
         self.normalization = normalization
 
-        if print_level > 0:
+        if print_level > 2:
             print("\nNMO = %d; NACT = %d; NO = %d; NV = %d" % (self.hfwfn.nbf, self.nt, self.no, self.nv))
 
         o = self.o
@@ -94,7 +94,7 @@ class mpwfn(object):
         Dijab = self.Dijab
 
         E0 = self.hfwfn.escf + self.hfwfn.H.enuc
-        if print_level > 0:
+        if print_level > 2:
             print("HFWFN ESCF (electronic) = ", self.hfwfn.escf)
             print("HFWFN ESCF (total) =      ", self.hfwfn.escf + self.hfwfn.enuc)
 
@@ -105,7 +105,7 @@ class mpwfn(object):
         # MP2 energy
         emp2 = self.compute_mp2_energy(o, v, L, C2)
 
-        if print_level > 0:
+        if print_level > 2:
             print("MP2 Correlation Energy = ", emp2)
             print("MP2 Total Energy       = ", emp2 + E0)
 
@@ -113,7 +113,7 @@ class mpwfn(object):
         if self.normalization == 'FULL':
             C0, C2 = self.normalize(o, v, C2)
             norm = np.sqrt(C0*C0 + contract('ijab,ijab->', (2*C2-C2.swapaxes(2,3)).conj(), C2))
-            if print_level > 0:
+            if print_level > 2:
                 print(f"Normalization check = {norm:18.12f}")
         self.C0 = C0
         self.C2 = C2

--- a/magpy/mpwfn_so.py
+++ b/magpy/mpwfn_so.py
@@ -107,7 +107,7 @@ class mpwfn_so(object):
             raise Exception(f"{normalization:s} is not an allowed choice of normalization.")
         self.normalization = normalization
 
-        if print_level > 0:
+        if print_level > 2:
             print("\nNMO = %d; NACT = %d; NO = %d; NV = %d" % (self.hfwfn.nbf, self.nt, self.no, self.nv))
 
         o = self.o
@@ -117,7 +117,7 @@ class mpwfn_so(object):
         Dijab = self.Dijab
 
         E0 = self.hfwfn.escf + self.hfwfn.H.enuc
-        if print_level > 0:
+        if print_level > 2:
             print("HFWFN ESCF (electronic) = ", self.hfwfn.escf)
             print("HFWFN ESCF (total) =      ", self.hfwfn.escf + self.hfwfn.enuc)
 
@@ -128,7 +128,7 @@ class mpwfn_so(object):
         # MP2 energy
         emp2 = self.compute_mp2_energy(o, v, ERI_oovv, C2)
 
-        if print_level > 0:
+        if print_level > 2:
             print("MP2 Correlation Energy = ", emp2)
             print("MP2 Total Energy       = ", emp2 + E0)
 
@@ -136,7 +136,7 @@ class mpwfn_so(object):
         if self.normalization == 'FULL':
             C0, C2 = self.normalize(o, v, C2)
             norm = np.sqrt(C0*C0 + (1/4) * contract('ijab,ijab', C2.conj(), C2))
-            if print_level > 0:
+            if print_level > 2:
                 print(f"Normalization check = {norm:18.12f}")
         self.C0 = C0
         self.C2 = C2

--- a/magpy/normal.py
+++ b/magpy/normal.py
@@ -33,7 +33,7 @@ def normal(molecule, method='HF', r_disp=0.001, f_disp=0.0001, b_disp=0.0001, **
         print(f"    Method = {method:s}")
         print(f"    parallel = {parallel}")
         if parallel is True:
-            print(f"    num_proc = {num_proc:d}")
+            print(f"    num_procs = {num_procs:d}")
         print(f"    r_disp = {r_disp:e}")
         print(f"    f_disp = {f_disp:e}")
         print(f"    b_disp = {b_disp:e}")

--- a/magpy/normal.py
+++ b/magpy/normal.py
@@ -26,6 +26,25 @@ def normal(molecule, method='HF', r_disp=0.001, f_disp=0.0001, b_disp=0.0001, **
     if read_hessian == True:
         fcm_file = kwargs.pop('fcm_file', 'fcm')
 
+    # Title output
+    if print_level >= 1:
+        print("IR and VCD Spectra Computation")
+        print(f"Method = {method:s}")
+        print(f"parallel = {parallel:s}")
+        if parallel is True:
+            print(f"num_proc = {num_proc:d}")
+        print(f"r_disp = {r_disp:f}")
+        print(f"f_disp = {f_disp:f}")
+        print(f"b_disp = {b_disp:f}")
+        print(f"e_conv = {e_conv:f}")
+        print(f"r_conv = {r_conv:f}")
+        print(f"maxiter = {maxiter:d}")
+        print(f"max_diis = {max_diis:d}")
+        print(f"start_diis = {start_diis:d}")
+        print(f"read_hessian = {read_hessian:s}")
+        if read_hessian is True:
+            print(f"fcm_file = {fcm_file:s}")
+
     # Physical constants and a few derived units
     _c = psi4.qcel.constants.get("speed of light in vacuum") # m/s
     _me = psi4.qcel.constants.get("electron mass") # kg

--- a/magpy/normal.py
+++ b/magpy/normal.py
@@ -21,7 +21,7 @@ def normal(molecule, method='HF', r_disp=0.001, f_disp=0.0001, b_disp=0.0001, **
     maxiter = kwargs.pop('maxiter', 400)
     max_diis = kwargs.pop('max_diis', 8)
     start_diis = kwargs.pop('start_diis', 1)
-    print_level = kwargs.pop('print_level', 0)
+    print_level = kwargs.pop('print_level', 1)
     read_hessian = kwargs.pop('read_hessian', False)
     if read_hessian == True:
         fcm_file = kwargs.pop('fcm_file', 'fcm')
@@ -29,21 +29,22 @@ def normal(molecule, method='HF', r_disp=0.001, f_disp=0.0001, b_disp=0.0001, **
     # Title output
     if print_level >= 1:
         print("IR and VCD Spectra Computation")
-        print(f"Method = {method:s}")
-        print(f"parallel = {parallel:s}")
+        print("==============================")
+        print(f"    Method = {method:s}")
+        print(f"    parallel = {parallel}")
         if parallel is True:
-            print(f"num_proc = {num_proc:d}")
-        print(f"r_disp = {r_disp:f}")
-        print(f"f_disp = {f_disp:f}")
-        print(f"b_disp = {b_disp:f}")
-        print(f"e_conv = {e_conv:f}")
-        print(f"r_conv = {r_conv:f}")
-        print(f"maxiter = {maxiter:d}")
-        print(f"max_diis = {max_diis:d}")
-        print(f"start_diis = {start_diis:d}")
-        print(f"read_hessian = {read_hessian:s}")
+            print(f"    num_proc = {num_proc:d}")
+        print(f"    r_disp = {r_disp:e}")
+        print(f"    f_disp = {f_disp:e}")
+        print(f"    b_disp = {b_disp:e}")
+        print(f"    e_conv = {e_conv:e}")
+        print(f"    r_conv = {r_conv:e}")
+        print(f"    maxiter = {maxiter:d}")
+        print(f"    max_diis = {max_diis:d}")
+        print(f"    start_diis = {start_diis:d}")
+        print(f"    read_hessian = {read_hessian}")
         if read_hessian is True:
-            print(f"fcm_file = {fcm_file:s}")
+            print(f"    fcm_file = {fcm_file:s}")
 
     # Physical constants and a few derived units
     _c = psi4.qcel.constants.get("speed of light in vacuum") # m/s

--- a/magpy/tests/test_005_AAT_CID.py
+++ b/magpy/tests/test_005_AAT_CID.py
@@ -28,7 +28,11 @@ def test_AAT_CID_H2DIMER():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
-    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='intermediate')
+    print_level = 1
+    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv,
+                                         normalization='intermediate',
+                                         print_level=print_level)
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
     print(I_00)
@@ -126,7 +130,10 @@ def test_AAT_CID_H2DIMER_NORM():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
-    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='full')
+    print_level = 1
+    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv, normalization='full',
+                                         print_level=print_level)
 
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
@@ -225,7 +232,11 @@ def test_AAT_CID_H2O():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
-    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='intermediate')
+    print_level = 1
+    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv,
+                                         normalization='intermediate',
+                                         print_level=print_level)
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
     print(I_00)
@@ -311,7 +322,10 @@ def test_AAT_CID_H2O_NORM():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
-    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='full')
+    print_level = 1
+    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv, normalization='full',
+                                         print_level=print_level)
 
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")

--- a/magpy/tests/test_021_VCD_MP2.py
+++ b/magpy/tests/test_021_VCD_MP2.py
@@ -17,7 +17,7 @@ def test_VCD_H2Dimer_STO3G():
                       'd_convergence': 1e-13,
                       'r_convergence': 1e-13})
 
-    psi4.set_options({'basis': 'STO-3G'})
+    psi4.set_options({'basis': 'STO-6G'})
     # CID/6-31G* optimized geometry from G09
     mol = psi4.geometry("""
     O       0.00000000          1.35909101         -0.103181170

--- a/magpy/tests/test_021_VCD_MP2.py
+++ b/magpy/tests/test_021_VCD_MP2.py
@@ -8,7 +8,7 @@ import os
 np.set_printoptions(precision=10, linewidth=200, threshold=200, suppress=True)
 
 #@pytest.mark.skip(reason="not ready")
-def test_VCD_H2Dimer_STO3G():
+def test_VCD_H2Dimer_STO3G(pytestconfig):
     psi4.core.clean_options()
     psi4.set_memory('2 GB')
     psi4.set_output_file('output.dat', False)
@@ -29,10 +29,10 @@ def test_VCD_H2Dimer_STO3G():
     noreorient
     no_com
     """)
-    print(os.getcwd())
+    fcm_file = str(pytestconfig.rootdir) + "/magpy/tests/fcm_H2O2_CID_631Gd.txt"
     num_procs = os.cpu_count()
     print_level = 1
-    magpy.normal(mol, 'MP2', read_hessian=True, fcm_file="fcm_H2O2_CID_631Gd.txt", parallel=True, num_procs=num_procs)
+    magpy.normal(mol, 'MP2', read_hessian=True, fcm_file=fcm_file, parallel=True, num_procs=num_procs)
 
 
 @pytest.mark.skip(reason="not ready")

--- a/magpy/tests/test_021_VCD_MP2.py
+++ b/magpy/tests/test_021_VCD_MP2.py
@@ -29,6 +29,7 @@ def test_VCD_H2Dimer_STO3G():
     noreorient
     no_com
     """)
+    print(os.getcwd())
     num_procs = os.cpu_count()
     print_level = 1
     magpy.normal(mol, 'MP2', read_hessian=True, fcm_file="fcm_H2O2_CID_631Gd.txt", parallel=True, num_procs=num_procs)

--- a/magpy/tests/test_021_VCD_MP2.py
+++ b/magpy/tests/test_021_VCD_MP2.py
@@ -7,7 +7,7 @@ import os
 
 np.set_printoptions(precision=10, linewidth=200, threshold=200, suppress=True)
 
-@pytest.mark.skip(reason="not ready")
+#@pytest.mark.skip(reason="not ready")
 def test_VCD_H2Dimer_STO3G():
     psi4.core.clean_options()
     psi4.set_memory('2 GB')
@@ -30,6 +30,7 @@ def test_VCD_H2Dimer_STO3G():
     no_com
     """)
     num_procs = os.cpu_count()
+    print_level = 1
     magpy.normal(mol, 'MP2', read_hessian=True, fcm_file="fcm_H2O2_CID_631Gd.txt", parallel=True, num_procs=num_procs)
 
 

--- a/magpy/tests/test_022_AAT_CID_parallel.py
+++ b/magpy/tests/test_022_AAT_CID_parallel.py
@@ -28,8 +28,13 @@ def test_AAT_CID_H2DIMER():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
+    print_level = 1
     num_proc = os.cpu_count()
-    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='intermediate', parallel=True, num_proc=num_proc)
+    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv,
+                                         normalization='intermediate',
+                                         parallel=True, num_proc=num_proc,
+                                         print_level=print_level)
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
     print(I_00)
@@ -127,8 +132,12 @@ def test_AAT_CID_H2DIMER_NORM():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12 
+    print_level = 1
     num_proc = os.cpu_count()
-    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='full', parallel=True, num_proc=num_proc)
+    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv, normalization='full',
+                                         parallel=True, num_proc=num_proc,
+                                         print_level=print_level)
 
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
@@ -227,8 +236,13 @@ def test_AAT_CID_H2O():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
+    print_level = 1
     num_proc = os.cpu_count()
-    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='intermediate', parallel=True, num_proc=num_proc)
+    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv,
+                                         normalization='intermediate',
+                                         parallel=True, num_proc=num_proc,
+                                         print_level=print_level)
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
     print(I_00)
@@ -314,8 +328,12 @@ def test_AAT_CID_H2O_NORM():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
+    print_level = 1
     num_proc = os.cpu_count()
-    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='full', parallel=True, num_proc=num_proc)
+    I_00, I_0D, I_D0, I_DD = AAT.compute('CID', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv, normalization='full',
+                                         parallel=True, num_proc=num_proc,
+                                         print_level=print_level)
 
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")

--- a/magpy/tests/test_024_AAT_MP2_parallel.py
+++ b/magpy/tests/test_024_AAT_MP2_parallel.py
@@ -29,7 +29,12 @@ def test_AAT_MP2_H2DIMER():
     e_conv = 1e-12
     r_conv = 1e-12
     num_procs = os.cpu_count()
-    I_00, I_0D, I_D0, I_DD = AAT.compute('MP2', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='intermediate', parallel=True, num_procs=num_procs)
+    print_level = 1
+    I_00, I_0D, I_D0, I_DD = AAT.compute('MP2', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv,
+                                         normalization='intermediate',
+                                         parallel=True, num_procs=num_procs,
+                                         print_level=print_level)
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
     print(I_00)
@@ -127,8 +132,12 @@ def test_AAT_MP2_H2DIMER_NORM():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
+    print_level = 1
     num_procs = os.cpu_count()
-    I_00, I_0D, I_D0, I_DD = AAT.compute('MP2', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='full', parallel=True, num_procs=num_procs)               
+    I_00, I_0D, I_D0, I_DD = AAT.compute('MP2', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv, normalization='full',
+                                         parallel=True, num_procs=num_procs,
+                                         print_level=print_level)
 
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
@@ -227,8 +236,13 @@ def test_AAT_MP2_H2O():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
+    print_level = 1
     num_procs = os.cpu_count()
-    I_00, I_0D, I_D0, I_DD = AAT.compute('MP2', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='intermediate', parallel=True, num_procs=num_procs)
+    I_00, I_0D, I_D0, I_DD = AAT.compute('MP2', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv,
+                                         normalization='intermediate',
+                                         parallel=True, num_procs=num_procs,
+                                         print_level=print_level)
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")
     print(I_00)
@@ -314,8 +328,12 @@ def test_AAT_MP2_H2O_NORM():
     b_disp = 0.0001
     e_conv = 1e-12
     r_conv = 1e-12
+    print_level = 1
     num_procs = os.cpu_count()
-    I_00, I_0D, I_D0, I_DD = AAT.compute('MP2', r_disp, b_disp, e_conv=e_conv, r_conv=r_conv, normalization='full', parallel=True, num_procs=num_procs)
+    I_00, I_0D, I_D0, I_DD = AAT.compute('MP2', r_disp, b_disp, e_conv=e_conv,
+                                         r_conv=r_conv, normalization='full',
+                                         parallel=True, num_procs=num_procs,
+                                         print_level=print_level)
 
     print("\nElectronic Contribution to Atomic Axial Tensor (a.u.):")
     print("Hartree-Fock component:")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+minversion = 6.0
+addopts = -ra
+testpaths =
+    tests


### PR DESCRIPTION
## Description
Adding printing options that are useful for identifying important parameters for later reproducibility.

## Todos
  - [X] Print options to `normal.py`
  - [X] Print options to `aat.py`
  - [X] Print options to `apt.py`
  - [X] Print options to `hfwfn.py`
  - [X] Print options to `mpwfn.py`
  - [X] Print options to `mpwfn_so.py`
  - [X] Print options to `ciwfn.py`
  - [X] Print options to `ciwfn_so.py`

## Questions
- [ ] Question1

## Status
- [X] Ready to go