### PR TITLE
Add workaround for numpy 2 to CI.

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -49,7 +49,7 @@ jobs:
         conda list --show-channel-urls
         hash -r
         env
-        conda install psi4 python=${{ matrix.python-version }} -c conda-forge
+        conda install psi4 python=${{ matrix.python-version }} numpy=1 -c conda-forge
         ls -l $CONDA
 
     - name: Test Psi4 Python Loading


### PR DESCRIPTION
## Description
Avoid NumPy 2 in CI for now.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [x] Ready to go